### PR TITLE
adds proxy server to remove jsonp for CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Ionic Test API
-An app built on cordova Ionic v1 that serves up API data from https://jsonplaceholder.typicode.com. Complete with Jasmine Karma and Protactor tests.
+An app built on Cordova Ionic v1 and serves up API data from https://jsonplaceholder.typicode.com. Complete with Jasmine Karma and Protractor tests.
 
 ## Getting started
 Install the following:
@@ -12,7 +12,7 @@ Install the following:
 ## To Run app
 Download the repo and inside the repo run
 `npm install`
-`gulp watch`
+`ionic serve`
 
 ## To run tests
 `gulp karma` for front end unit tests with jasmine

--- a/app/main/controllers/edit-item-ctrl.js
+++ b/app/main/controllers/edit-item-ctrl.js
@@ -10,10 +10,11 @@ angular.module('main')
   }.bind(this));
 
   this.saveItem = function (title, body) {
+    this.saved = true;
+    this.saveMessage = 'Saving...';
 
     Main.saveItem(this.id, title, body, function (data) {
-      if(data) {
-        this.saved = true;
+      if (data) {
         this.saveMessage = 'Saved!!';
       } else {
         this.saveMessage = 'Not Saved';

--- a/app/main/services/main-serv.js
+++ b/app/main/services/main-serv.js
@@ -1,36 +1,24 @@
 'use strict';
 angular.module('main')
 .service('Main', function ($log, $timeout, $http) {
-  var apiPath = 'https://jsonplaceholder.typicode.com/posts';
+  var apiPath = '/posts';
 
   this.getListData = function (callback) {
+    var dataUrl = apiPath;
 
-    $http.jsonp(apiPath + '?callback=JSON_CALLBACK')
+    $http.get(dataUrl)
     .success(function (response) {
       callback(response);
     })
     .error(function (err) {
-      throw Error('JSONP ERROR!', err);
+      throw Error('ERROR!', err);
     });
   };
-
-  // TODO: Implement proxy server to remove CORS
-  // this.getListData = function (callback) {
-  //   var dataUrl = '/posts';
-  //
-  //   $http.get(dataUrl)
-  //   .success(function (response) {
-  //     callback(response);
-  //   })
-  //   .error(function (err) {
-  //     throw Error('ERROR!', err);
-  //   });
-  // };
 
   this.getItemData = function (id, callback) {
     var dataUrl = apiPath + '/' + id;
 
-    $http.jsonp(dataUrl + '?callback=JSON_CALLBACK')
+    $http.get(dataUrl)
     .success(function (response) {
       callback(response);
     })

--- a/app/main/templates/list-detail.html
+++ b/app/main/templates/list-detail.html
@@ -1,4 +1,4 @@
-<ion-view view-title="Item Detail">
+<ion-view view-title="Item DetailSSSSS">
   <!-- do you want padding -->
   <ion-content class="padding">
     <button class="button button-block button-dark"

--- a/ionic.config.json
+++ b/ionic.config.json
@@ -3,6 +3,7 @@
   "app_id": "",
   "v2": true,
   "typescript": true,
+  "documentRoot": "/app/",
   "proxies": [
     {
       "path": "/posts",


### PR DESCRIPTION
#### What's this PR do?
Adds a proxy server to the project in `ionic.config.json` so that there is no concern over CORS
#### What are the important parts of the code?
The `ionic.config.json` was included which serves as the proxy server and the `main.serv.js` has been updated to use `$http.get` instead of `$http.jsonp` 
#### How should this be tested by the reviewer?
Run the app using `ionic serve`, navigate to the lists tab and click on a title, then click the edit button, then click save.
#### Is any other information necessary to understand this?
Browsers do not allow one web front end to talk to another as a security measure. Jsonp is a work around for that but it's better to put your data requests on the back end, so adding this proxy server removes the risk of cross side scripting and moves the call to retrieve data to the back end.
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
Closes #12 
#### Screenshots (if appropriate)
![screen shot 2017-04-11 at 12 22 17 pm](https://cloud.githubusercontent.com/assets/6709858/24926761/8cad3dde-1eb1-11e7-90f4-9ff9e69cc004.png)

#### Documentation / Release notes updated?
Implementing this proxy server required running `ionic serve`. The scaffold was not set up using `ionic serve` to run the app. I had to modify the default location which `ionic serve` uses, as well as update the readme to start the app with `ionic serve` instead of `gulp serve`.
